### PR TITLE
fix: coalesce edits on the same file

### DIFF
--- a/genericMap.go
+++ b/genericMap.go
@@ -14,8 +14,8 @@ type set Map[string, struct{}]
 
 // generic methods, kinda
 
-func (c theme_info) Map() Map[string, string] {
-	return Map[string, string](c)
+func (t theme_info) Map() Map[string, string] {
+	return Map[string, string](t)
 }
 
 func (s set) Map() Map[string, struct{}] {


### PR DESCRIPTION
attempts to fix #5 by making edits that target the same file one after the other in the same goroutine, instead of at the same time by different goroutines

Does this by introducing the concept of "Edits", a map from filepaths to lists of Configs.

TODO: maybe some renaming is in order?